### PR TITLE
Fix corner case when top node in ipTree is removed

### DIFF
--- a/ipset_test.go
+++ b/ipset_test.go
@@ -197,6 +197,20 @@ func TestIPSetRemoveAll(t *testing.T) {
 	assert.False(t, set.ContainsNet(cidr1))
 }
 
+func TestIPSet_RemoveTop(t *testing.T) {
+	testSet := IPSet{}
+	ip1 := net.ParseIP("10.0.0.1")
+	ip2 := net.ParseIP("10.0.0.2")
+
+	testSet.Insert(ip2) // top
+	testSet.Insert(ip1) // inserted at left
+	testSet.Remove(ip2) // remove top node
+
+	assert.True(t, testSet.Contains(ip1))
+	assert.False(t, testSet.Contains(ip2))
+	assert.Nil(t, testSet.tree.next())
+}
+
 func TestIPSetInsertOverlapping(t *testing.T) {
 	set := IPSet{}
 

--- a/iptree.go
+++ b/iptree.go
@@ -118,6 +118,8 @@ func (t *ipTree) remove() *ipTree {
 			} else {
 				t.up.setRight(newChild)
 			}
+		} else if newChild != nil {
+			newChild.up = t.up
 		}
 		return newChild
 	}


### PR DESCRIPTION
When the top node is removed, the newChild's up node must be set to
nil. Without this, the tree.next() traversal function will find the
removed node.