### PR TITLE
Implement Equal

### DIFF
--- a/ipset.go
+++ b/ipset.go
@@ -76,6 +76,29 @@ func (s *IPSet) Contains(ip net.IP) bool {
 	return s.ContainsNet(ipToNet(ip))
 }
 
+// Equal returns true iff this set contains the same IPs as the other
+func (s *IPSet) Equal(other *IPSet) bool {
+	a, b := s.tree.first(), other.tree.first()
+
+	for ; a != nil && b != nil; a, b = a.next(), b.next() {
+		if !EqualNet(a.net, b.net) {
+			return false
+		}
+	}
+
+	return a == b
+}
+
+// EqualInterface returns true iff this set contains the same IPs as the other
+func (s *IPSet) EqualInterface(other interface{}) bool {
+	switch o := other.(type) {
+	case *IPSet:
+		return s.Equal(o)
+	default:
+		return false
+	}
+}
+
 // Union computes the union of this IPSet and another set. It returns the
 // result as a new set.
 func (s *IPSet) Union(other *IPSet) (newSet *IPSet) {

--- a/iptree.go
+++ b/iptree.go
@@ -84,7 +84,7 @@ func (t *ipTree) insert(newNode *ipTree) *ipTree {
 		return newNode
 	}
 
-	if bytes.Compare(newNode.net.IP, t.net.IP) < 0 {
+	if IPLessThan(newNode.net.IP, t.net.IP) {
 		t.setLeft(t.left.insert(newNode))
 	} else {
 		t.setRight(t.right.insert(newNode))
@@ -104,7 +104,7 @@ func (t *ipTree) contains(newNode *ipTree) bool {
 	if ContainsNet(newNode.net, t.net) {
 		return false
 	}
-	if bytes.Compare(newNode.net.IP, t.net.IP) < 0 {
+	if IPLessThan(newNode.net.IP, t.net.IP) {
 		return t.left.contains(newNode)
 	}
 	return t.right.contains(newNode)
@@ -146,7 +146,7 @@ func (t *ipTree) removeNet(net *net.IPNet) (top *ipTree) {
 		return
 	}
 	// If net starts before me.net, recursively remove net from the left
-	if bytes.Compare(net.IP, t.net.IP) < 0 {
+	if IPLessThan(net.IP, t.net.IP) {
 		t.left = t.left.removeNet(net)
 	}
 
@@ -154,7 +154,7 @@ func (t *ipTree) removeNet(net *net.IPNet) (top *ipTree) {
 	// the right
 	diff := netDifference(net, t.net)
 	for _, n := range diff {
-		if bytes.Compare(t.net.IP, n.IP) < 0 {
+		if IPLessThan(t.net.IP, n.IP) {
 			t.right = t.right.removeNet(net)
 			break
 		}

--- a/iptree.go
+++ b/iptree.go
@@ -1,7 +1,6 @@
 package netaddr
 
 import (
-	"bytes"
 	"errors"
 	"math/big"
 	"net"
@@ -305,9 +304,17 @@ func (t *ipTree) validate() []error {
 		}
 
 		// assert order is correct
-		if lastNode != nil && bytes.Compare(lastNode.net.IP, n.net.IP) >= 0 {
-			errs = append(errs, errors.New("nodes must be in order: "+lastNode.net.IP.String()+" !< "+n.net.IP.String()))
+		if lastNode != nil {
+			if !IPLessThan(lastNode.net.IP, n.net.IP) {
+				errs = append(errs, errors.New("nodes must be in order: "+lastNode.net.IP.String()+" !< "+n.net.IP.String()))
+			}
+			// assert that nodes cannot be combined
+			mustCombine, _ := canCombineNets(lastNode.net, n.net)
+			if mustCombine {
+				errs = append(errs, errors.New("nodes must be combined: "+lastNode.net.String()+", "+n.net.String()))
+			}
 		}
+
 		lastNode = n
 	})
 

--- a/iptree_test.go
+++ b/iptree_test.go
@@ -42,6 +42,7 @@ func TestValidateBadLinkageLeft(t *testing.T) {
 	}
 	assert.Equal(t, []error{
 		errors.New("linkage error: left.up node must equal node"),
+		errors.New("nodes must be combined: 10.0.0.0/24, 10.0.1.0/24"),
 	}, tree.validate())
 }
 
@@ -54,6 +55,7 @@ func TestValidateBadLinkageRight(t *testing.T) {
 	}
 	assert.Equal(t, []error{
 		errors.New("linkage error: right.up node must equal node"),
+		errors.New("nodes must be combined: 10.0.0.0/24, 10.0.1.0/24"),
 	}, tree.validate())
 }
 
@@ -75,6 +77,7 @@ func TestValidateOutOfOrder(t *testing.T) {
 	assert.Equal(t, []error{
 		errors.New("nodes must be in order: 10.0.2.0 !< 10.0.1.0"),
 		errors.New("nodes must be in order: 10.0.1.0 !< 10.0.0.0"),
+		errors.New("nodes must be combined: 10.0.1.0/24, 10.0.0.0/24"),
 		errors.New("nodes must be in order: 10.0.0.0 !< 10.0.0.0"),
 	}, tree.validate())
 }

--- a/net_utils.go
+++ b/net_utils.go
@@ -99,6 +99,11 @@ func BroadcastAddr(n *net.IPNet) net.IP {
 	return broadcast
 }
 
+// EqualNet returns true iff a and b are the same network
+func EqualNet(a, b *net.IPNet) bool {
+	return a.IP.Equal(b.IP) && bytes.Equal(a.Mask, b.Mask)
+}
+
 // ContainsNet returns true if net2 is a subset of net1. To be clear, it
 // returns true if net1 == net2 also.
 func ContainsNet(net1, net2 *net.IPNet) bool {

--- a/net_utils.go
+++ b/net_utils.go
@@ -262,12 +262,7 @@ func IPLessThan(a, b net.IP) bool {
 	if len(a) != len(b) { // ipv6 comes after ipv4
 		return len(a) < len(b)
 	}
-	for i := range a { // go left to right and compare each one
-		if a[i] != b[i] {
-			return a[i] < b[i]
-		}
-	}
-	return false // they are equal
+	return bytes.Compare(a, b) < 0
 }
 
 // IPMin returns the minimum of a and b


### PR DESCRIPTION
Implementing Equal for IPSet enables using them as values in [IPMaps][1]

[1]: https://github.com/IBM/netaddr/pull/24

I actually came across a couple of minor issues while implementing this and fixed them in the first few commits.